### PR TITLE
fix: broken server URL

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -9,7 +9,7 @@ info:
   title: Suger API
   version: "1.0"
 servers:
-- url: //https://api.suger.cloud/
+- url: https://api.suger.cloud/
 tags:
 - description: Access to API client resources
   name: API

--- a/configuration.go
+++ b/configuration.go
@@ -94,7 +94,7 @@ func NewConfiguration() *Configuration {
 		Debug:         false,
 		Servers: ServerConfigurations{
 			{
-				URL:         "//https://api.suger.cloud",
+				URL:         "https://api.suger.cloud",
 				Description: "No description provided",
 			},
 		},


### PR DESCRIPTION
The Go SDK completely fails with the current config